### PR TITLE
Enable usage in enviroments without C drive letter

### DIFF
--- a/platformSpecific/windowsSpecific.py
+++ b/platformSpecific/windowsSpecific.py
@@ -2,67 +2,57 @@ import os
 import sqlite3
 
 def setupWindowsBackend():
-    userName = os.getlogin()
     connection = None
 
     try:
-        connection = sqlite3.connect(f"C:\\Users\\{userName}\\Documents\\EmuGUI\\virtual_machines.sqlite")
+        connection = sqlite3.connect(f"{os.environ['USERPROFILE']}\\Documents\\EmuGUI\\virtual_machines.sqlite")
         print("Connection established.")
-    
+
     except sqlite3.Error as e:
         print(f"The SQLite module encountered an error: {e}. Trying to create the file.")
 
         try:
             windowsCreEmuGUIFolder()
-            file = open(f"C:\\Users\\{userName}\\Documents\\EmuGUI\\virtual_machines.sqlite", "w+")
+            file = open(f"{os.environ['USERPROFILE']}\\Documents\\EmuGUI\\virtual_machines.sqlite", "w+")
             file.close()
-        
+
         except:
             print("EmuGUI wasn't able to create the file.")
 
         try:
-            connection = sqlite3.connect(f"C:\\Users\\{userName}\\Documents\\EmuGUI\\virtual_machines.sqlite")
+            connection = sqlite3.connect(f"{os.environ['USERPROFILE']}\\Documents\\EmuGUI\\virtual_machines.sqlite")
             print("Connection established.")
 
         except sqlite3.Error as e:
             print(f"The SQLite module encountered an error: {e}.")
-    
+
     return connection
 
 def windowsTempVmStarterFile():
-    userName = os.getlogin()
-    fileName = f"C:\\Users\\{userName}\\Documents\\EmuGUI\\vmstart.txt"
+    fileName = f"{os.environ['USERPROFILE']}\\Documents\\EmuGUI\\vmstart.txt"
     return fileName
 
 def windowsLanguageFile():
-    userName = os.getlogin()
-    fileName = f"C:\\Users\\{userName}\\Documents\\EmuGUI\\lang.txt"
+    fileName = f"{os.environ['USERPROFILE']}\\Documents\\EmuGUI\\lang.txt"
     return fileName
 
 def windowsUpdateFile():
-    userName = os.getlogin()
-    fileName = f"C:\\Users\\{userName}\\Documents\\EmuGUI\\update.txt"
+    fileName = f"{os.environ['USERPROFILE']}\\Documents\\EmuGUI\\update.txt"
     return fileName
 
 def windowsExportFile():
-    userName = os.getlogin()
-    fileName = f"C:\\Users\\{userName}\\Documents\\EmuGUI\\vmdef.txt"
+    fileName = f"{os.environ['USERPROFILE']}\\Documents\\EmuGUI\\vmdef.txt"
     return fileName
 
 def windowsErrorFile():
-    userName = os.getlogin()
+    fileName = f"{os.environ['USERPROFILE']}\\Documents\\EmuGUI\\error.txt"
 
-    fileName = f"C:\\Users\\{userName}\\Documents\\EmuGUI\\error.txt"
-        
     return fileName
 
 def windowsLogFile(logID):
-    userName = os.getlogin()
+    fileName = f"{os.environ['USERPROFILE']}\\Documents\\EmuGUI\\log-{logID}.txt"
 
-    fileName = f"C:\\Users\\{userName}\\Documents\\EmuGUI\\log-{logID}.txt"
-        
     return fileName
 
 def windowsCreEmuGUIFolder():
-    userName = os.getlogin()
-    os.mkdir(f"C:\\Users\\{userName}\\Documents\\EmuGUI")
+    os.mkdir(f"{os.environ['USERPROFILE']}\\Documents\\EmuGUI")

--- a/platformSpecific/windowsSpecific.py
+++ b/platformSpecific/windowsSpecific.py
@@ -1,5 +1,6 @@
 import os
 import sqlite3
+from pathlib import Path
 
 def setupWindowsBackend():
     connection = None
@@ -55,4 +56,4 @@ def windowsLogFile(logID):
     return fileName
 
 def windowsCreEmuGUIFolder():
-    os.mkdir(f"{os.environ['USERPROFILE']}\\Documents\\EmuGUI")
+    Path(f"{os.environ['USERPROFILE']}\\Documents\\EmuGUI").mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
The C drive letter is not required to use Windows. Using `%USERPROFILE%` is a much better idea than hardcoding the system drive.
This also enable portability of the data folder simply by redefining the env variable in a batch file.